### PR TITLE
This PR includes a set of usability improvements for the Duo Auth Proxy Docker project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,31 @@ Builds Container for DUO Authproxy based on latest version.
 The Container is build weekly with the latest DUO Authproxy version and Container Image updates.
 
 ## Usage:
+To register your Duo Authenticaton Proxy, create `duo_enrollment.key` in your docker compose directory. Add your enrollment key on the first line of that file, from the Duo Admin authentication proxy section.
+
+Create the following directories in your docker compose directory:
+- `./log`
+- `./conf`
+- `./etc/duoauthproxy`
+- `./entrypoint`
+
+Create the entrypoint.sh script in `.entrypoint`
+```
+#!/bin/bash
+set -e
+
+if [ ! -f /etc/duoauthproxy/secrets ]; then
+  echo "Running Duo SSO enrollment..."
+  key=$(cat /run/secrets/duo_enrollment_key)
+  /opt/duoauthproxy/bin/authproxy_update_sso_enrollment_code "$key" \
+    && /opt/duoauthproxy/bin/authproxyctl restart
+else
+        echo "Skipping Enrollment as already enrolled."
+fi
+
+# Run cmd
+exec /opt/duoauthproxy/bin/authproxy
+```
 
 Mount your `authproxy.cfg` in `/opt/duoauthproxy/conf` otherwise the container fails to start.
 For Container logs to work the logging secion in `[main]`has to be setup correctly
@@ -32,19 +57,45 @@ log_stdout=true
 ### Docker-compose
 
 ```
----
-version: '3'
 services:
   duo-auth-proxy:
     image: oliverl21/duo-auth-proxy
     container_name: duo-authproxy
     restart: always
     volumes:
-      - /opt/docker/duo-authproxy/log:/opt/duoauthproxy/log
-      - /opt/docker/duo-authproxy/conf/authproxy.cfg:/opt/duoauthproxy/conf/authproxy.cfg
+      - ./log:/opt/duoauthproxy/log
+      - ./conf/authproxy.cfg:/opt/duoauthproxy/conf/authproxy.cfg
+      - ./entrypoint:/opt/duoauthproxy/entrypoint
+      - ./etc/duoauthproxy:/etc/duoauthproxy
     ports:
       - 1812:1812/udp
       - 1813:1813/udp
+    networks:
+      - duoproxy
+    entrypoint: /opt/duoauthproxy/entrypoint/entrypoint.sh
+    secrets:
+      - duo_enrollment_key
+
+secrets:
+  duo_enrollment_key:
+    file: ./duo_enrollment.key
+
+networks:
+  duoproxy:
+```
+
+The directory structure should look like:
+```
+duoproxy/                              # Root directory
+├── docker-compose.yml                 # Main Compose file
+├── duo_enrollment.key                 # 🔐 Docker secret (enrollment token)
+├── entrypoint/                        # Entrypoint script logic
+│   └── entrypoint.sh
+├── conf/                              # Contains authproxy.cfg
+│   └── authproxy.cfg
+├── log/                               # Duo Auth Proxy logs
+└── etc/
+    └── duoauthproxy/                  # Location for secret key storage (secrets)
 ```
 
 ## To-Do:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  duo-auth-proxy:
+    image: oliverl21/duo-auth-proxy
+    container_name: duo-authproxy
+    restart: always
+    volumes:
+      - ./log:/opt/duoauthproxy/log
+      - ./conf/authproxy.cfg:/opt/duoauthproxy/conf/authproxy.cfg
+      - ./entrypoint:/opt/duoauthproxy/entrypoint
+      - ./etc/duoauthproxy:/etc/duoauthproxy
+    ports:
+      - 1812:1812/udp
+      - 1813:1813/udp
+    networks:
+      - duoproxy
+    entrypoint: /opt/duoauthproxy/entrypoint/entrypoint.sh
+    secrets:
+      - duo_enrollment_key
+
+secrets:
+  duo_enrollment_key:
+    file: ./duo_enrollment.key
+
+networks:
+  duoproxy:

--- a/duo_enrollment.key
+++ b/duo_enrollment.key
@@ -1,0 +1,1 @@
+#replace this line with your enrollment key

--- a/entrypoint/entrypoint.sh
+++ b/entrypoint/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ ! -f /etc/duoauthproxy/secrets ]; then
+  echo "Running Duo SSO enrollment..."
+  key=$(cat /run/secrets/duo_enrollment_key)
+  /opt/duoauthproxy/bin/authproxy_update_sso_enrollment_code "$key" \
+    && /opt/duoauthproxy/bin/authproxyctl restart
+else
+        echo "Skipping Enrollment as already enrolled."
+fi
+
+# Run cmd
+exec /opt/duoauthproxy/bin/authproxy


### PR DESCRIPTION
## Summary
This PR includes a set of usability improvements for the Duo Auth Proxy Docker project.

## Changes
- Created a workflow to enrol the Authentication proxy
- Documented the directory/file structure to support the authentication proxy enrollment
- Created an entrypoint script to handle the enrolment if not already enrolled
- Updated docker compose file for best practices and to support the enrollment workflow
- Enrollment key is stored in a Docker Secrets file - key is invalidated by Duo after 8 hours of creation in the Duo portal

## Motivation
These changes aim to align with more conventional docker compose standards (version directive is deprecated) and make the setup easier to manage and understand. Added a usability feature for registration of the Auth Proxy

## Testing
- Successfully ran the container using the updated Compose file
- Verified secret persistence and one-time enrollment behaviour
- Confirmed proxy service starts as expected after enrollment
- Confirmed proxy appears connected in the Duo authentication proxy dashboard

Let me know if any changes or clarifications are needed!